### PR TITLE
[sdl] Add patch to force output rotation

### DIFF
--- a/rpm/0002-wayland-Add-hint-to-force-output-transform.patch
+++ b/rpm/0002-wayland-Add-hint-to-force-output-transform.patch
@@ -1,0 +1,89 @@
+commit a340c6708a479f0d08df060a8099e9b229bbd085
+Author: Peter G. (nephros) <sailfish@nephros.org>
+Date:   Tue May 19 10:04:35 2026 +0200
+
+    Sailfish OS: Add hint to rotate the Wayland output
+
+diff --git a/include/SDL_hints.h b/include/SDL_hints.h
+index 8c38d86..5469982 100644
+--- a/include/SDL_hints.h
++++ b/include/SDL_hints.h
+@@ -1966,6 +1966,28 @@ extern "C" {
+  */
+ #define SDL_HINT_VIDEO_MAC_FULLSCREEN_SPACES    "SDL_VIDEO_MAC_FULLSCREEN_SPACES"
+ 
++/**
++ * \brief A variable controlling whether the Wayland output is rotated.
++ *
++ * The Wayland buffer will have a transformation corresponding to the value used applied.
++ *
++ * The variable can be set to the following values:
++ *
++ * - "0":  No forced rotation (default)
++ * - "90":  rotate by 90 degrees counter-clockwise.
++ * - "180": rotate by 180 degrees counter-clockwise.
++ * - "270": rotate by 270 degrees counter-clockwise.
++ * - "0f":  180 degree flip around a vertical axis.
++ * - "90f": flip and rotate 90 degrees counter-clockwise
++ * - "180f": flip and rotate 180 degrees counter-clockwise
++ * - "270f": flip and rotate 270 degrees counter-clockwise
++ *
++ * This hint should be set before the main window is created.
++ *
++ * \sa wl_surface_set_buffer_transform
++ */
++#define SDL_HINT_VIDEO_SAILFISHOS_FORCE_ROTATION "SDL_VIDEO_SAILFISHOS_FORCE_ROTATION"
++
+ /**
+  *  \brief Minimize your SDL_Window if it loses key focus when in fullscreen mode. Defaults to false.
+  *  \warning  Before SDL 2.0.14, this defaulted to true! In 2.0.14, we're
+diff --git a/src/video/wayland/SDL_waylandwindow.c b/src/video/wayland/SDL_waylandwindow.c
+index 18a6b14..e00807f 100644
+--- a/src/video/wayland/SDL_waylandwindow.c
++++ b/src/video/wayland/SDL_waylandwindow.c
+@@ -1977,6 +1977,45 @@ int Wayland_CreateWindow(_THIS, SDL_Window *window)
+                                wl_fixed_from_int(-1), wl_fixed_from_int(-1));
+     }
+ 
++{
++    const char* forced_rotation = SDL_GetHint(SDL_HINT_VIDEO_SAILFISHOS_FORCE_ROTATION);
++    if (forced_rotation != NULL) {
++        uint transform = 0;
++        if (SDL_strcmp("0", forced_rotation) == 0) {
++            transform = WL_OUTPUT_TRANSFORM_NORMAL;
++        } else
++        if (SDL_strcmp("90", forced_rotation) == 0) {
++            transform = WL_OUTPUT_TRANSFORM_90;
++        } else
++        if (SDL_strcmp("180", forced_rotation) == 0) {
++            transform = WL_OUTPUT_TRANSFORM_180;
++        } else
++        if (SDL_strcmp("270", forced_rotation) == 0) {
++            transform = WL_OUTPUT_TRANSFORM_270;
++        } else
++        if (SDL_strcmp("0f", forced_rotation) == 0) {
++            transform = WL_OUTPUT_TRANSFORM_FLIPPED;
++        } else
++        if (SDL_strcmp("90f", forced_rotation) == 0) {
++            transform = WL_OUTPUT_TRANSFORM_FLIPPED_90;
++        } else
++        if (SDL_strcmp("180f", forced_rotation) == 0) {
++            transform = WL_OUTPUT_TRANSFORM_FLIPPED_180;
++        } else
++        if (SDL_strcmp("270f", forced_rotation) == 0) {
++            transform = WL_OUTPUT_TRANSFORM_FLIPPED_270;
++        }
++
++        SDL_LogInfo(SDL_LOG_CATEGORY_VIDEO, "Wayland: forcing output transformation: %s (%d)", forced_rotation, transform);
++        if(!data->surface) {
++            SDL_LogError(SDL_LOG_CATEGORY_VIDEO, "Wayland: forcing output transformation: no wl_surface!");
++        } else {
++            wl_surface_set_buffer_transform(data->surface, transform);
++        }
++    } else {
++        SDL_LogDebug(SDL_LOG_CATEGORY_VIDEO, "Wayland: not forcing output transformation");
++    }
++}
+     /* Must be called before EGL configuration to set the drawable backbuffer size. */
+     ConfigureWindowGeometry(window);
+ 


### PR DESCRIPTION
This adds an SDL_Hint allowing applications to specify wl_output
transform.

Landscape/Portrait handling in SDL is problematic (very few/no
applications have it), this becomes a huge pain in porting games to
Sailfish, as rotation must always be added/implemented manually, often
leading to more work as input must be adjusted as well.

Having this option available as a Hint makes this porting work much
easier.
